### PR TITLE
Cloud Shell - Google Cloud: Free VPS Lifetime 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Step 2: Paste this code to CloudShell Terminal: docker run -p 8080:80 dorowu/ubu
 Step 3: Click to "Web preview" icon on menu, select "Preview on port xxxx"<br>
 Note: 
 * If error, change 8080 to 7080 or 6080<br>
-* The default weekly Cloud Shell quota is 50 hours.<br>
+* The default weekly Cloud Shell quota is 50 hours (Check in "Session infomation").<br>
 ![Free-RDP-VPS-google-cloud-shell-VietTube](https://github.com/user-attachments/assets/66439255-5b6f-4baf-a49a-7907ab91bf02)
 ***
 * Intel(R) Xeon(R) CPU @ 2.20GHz


### PR DESCRIPTION
@Copyright: https://bloggeroffer.blogspot.com<br>
Step 1: Visit https://shell.cloud.google.com/?hl=en_US&fromcloudshell=true&show=ide%2Cterminal<br>
Step 2: Paste this code to CloudShell Terminal: `docker run -p 8080:80 dorowu/ubuntu-desktop-lxde-vnc`<br>
Step 3: Click to "Web preview" icon on menu, select "Preview on port xxxx"<br>
Note: 
* If error, change 8080 to 7080 or 6080<br>
* The default weekly Cloud Shell quota is 50 hours (Check in "Session information"). <br>
![Free-RDP-VPS-google-cloud-shell-VietTube](https://github.com/user-attachments/assets/66439255-5b6f-4baf-a49a-7907ab91bf02)
***
* Intel(R) Xeon(R) CPU @ 2.20GHz
* 8GB RAM
* Internet speed: Download 500 Mbps, Upload: 600 Mbps
***
Cloud Shell - Google Cloud: Free VPS Lifetime 2024
***
Contact: https://youtube.com/@giapca
