### PR TITLE
Fix Windows 7 Ultimate 32bit Update Error 80072EFE

### DIFF
--- a/Win7x86
+++ b/Win7x86
@@ -1,0 +1,7 @@
+Fix Windows 7 Ultimate Update Error 80072EFE
+1. Download Firefox
+2. Download Hotfix:
+Fix 80072EFE: KB3138612
+https://catalog.s.download.windowsupdate.com/d/msdownload/update/software/updt/2016/02/windows6.1-kb3138612-x86_6e90531daffc13bc4e92ecea890e501e807c621f.msu
+
+Fix 80092004: KB4490628


### PR DESCRIPTION
### Fix Windows 7 Ultimate 32bit Update Error 80072EFE
1. Download Firefox
https://download-installer.cdn.mozilla.net/pub/firefox/releases/130.0.1/win32/en-US/Firefox%20Setup%20130.0.1.exe
Other Old Firefox Versions:
https://ftp.mozilla.org/pub/firefox/releases/
2. Download Hotfix: https://www.catalog.update.microsoft.com/Home.aspx
Fix 80072EFE: KB3138612
https://catalog.s.download.windowsupdate.com/d/msdownload/update/software/updt/2016/02/windows6.1-kb3138612-x86_6e90531daffc13bc4e92ecea890e501e807c621f.msu

Fix 80092004: KB4490628
https://catalog.s.download.windowsupdate.com/c/msdownload/update/software/secu/2019/03/windows6.1-kb4490628-x86_3cdb3df55b9cd7ef7fcb24fc4e237ea287ad0992.msu

Fix 80246002: KB3006137
https://catalog.s.download.windowsupdate.com/d/msdownload/update/software/updt/2015/02/windows6.1-kb3006137-x86_4a93f03431d6f85334822910e585bc32d5f261d0.msu

Fix 80072EE2: Turn off Firewall
